### PR TITLE
Refactor Note Timestamps: Replace Single Value with Structured Start/End Object

### DIFF
--- a/apps/client/src/features/note/pages/create-note.page.tsx
+++ b/apps/client/src/features/note/pages/create-note.page.tsx
@@ -4,7 +4,7 @@ import { useCreateNote } from "@/features/note/hooks";
 import { useGetVideoById } from "@/features/video/hooks";
 
 import { NotePageLayout } from "@/features/note/components";
-import { useVideoStore } from "@/features/video/store";
+import { useNoteStore } from "../store";
 
 interface IPageProps {
   videoId: string;
@@ -12,11 +12,13 @@ interface IPageProps {
 
 export function CreateNotePage({ videoId }: IPageProps) {
   const { mutate: createNote, isPending: isSavingNote } = useCreateNote();
-  const { videoCurrentTime } = useVideoStore();
+  const { noteTimestamp } = useNoteStore();
   const { data: videoData, isLoading } = useGetVideoById(videoId);
 
   const handleCreateNote = (noteTitle: string, content: string) => {
     if (!videoData) return;
+
+    console.log("Note Timestamp:", noteTimestamp);
 
     createNote({
       videoId: videoData.id,
@@ -26,7 +28,7 @@ export function CreateNotePage({ videoId }: IPageProps) {
         thumbnail: videoData.thumbnails.medium.url,
         videoTitle: videoData.title,
         youtubeId: videoData.youtubeId,
-        timestamp: videoCurrentTime,
+        timestamp: noteTimestamp,
       },
     });
   };

--- a/apps/client/src/features/note/pages/update-note.page.tsx
+++ b/apps/client/src/features/note/pages/update-note.page.tsx
@@ -3,7 +3,7 @@
 import { useGetNoteById, useUpdateNote } from "@/features/note/hooks";
 
 import { NotePageLayout } from "@/features/note/components";
-import { useVideoStore } from "@/features/video/store";
+import { useNoteStore } from "../store";
 
 interface IPageProps {
   noteId: string;
@@ -11,7 +11,7 @@ interface IPageProps {
 
 export function UpdateNotePage({ noteId }: IPageProps) {
   const { mutate: updateNote, isPending: isUpdatingNote } = useUpdateNote();
-  const { videoCurrentTime } = useVideoStore();
+  const { noteTimestamp } = useNoteStore();
   const { data: note, isLoading, isError } = useGetNoteById(noteId);
 
   const handleUpdateNote = (noteTitle: string, content: string) => {
@@ -22,7 +22,7 @@ export function UpdateNotePage({ noteId }: IPageProps) {
       updateData: {
         title: noteTitle,
         content: content,
-        timestamp: videoCurrentTime,
+        timestamp: noteTimestamp,
       },
     });
   };

--- a/apps/client/src/features/note/store/note.store.ts
+++ b/apps/client/src/features/note/store/note.store.ts
@@ -1,12 +1,13 @@
 "use client";
 
-import type { Note } from "@tubenote/db";
+import type { Note, Timestamp } from "@tubenote/db";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 
 interface NoteState {
   note: Note | undefined;
   selectedNoteId: string | null;
+  noteTimestamp: Timestamp;
   isCreating: boolean;
   isUpdating: boolean;
   isDeleting: boolean;
@@ -18,6 +19,7 @@ interface NoteStore extends NoteState {
   noteActions: {
     setNote: (note: Note | undefined) => void;
     setNoteId: (id: string | null) => void;
+    setNoteTimestamp: (timestamp: Timestamp) => void;
     setCreating: (isCreating: boolean) => void;
     setUpdating: (isUpdating: boolean) => void;
     setDeleting: (isDeleting: boolean) => void;
@@ -29,6 +31,10 @@ interface NoteStore extends NoteState {
 export const useNoteStore = create<NoteStore>()(
   immer((set) => ({
     note: undefined,
+    noteTimestamp: {
+      start: 0,
+      end: 0,
+    },
     selectedNoteId: null,
     isCreating: false,
     isUpdating: false,
@@ -40,6 +46,11 @@ export const useNoteStore = create<NoteStore>()(
       setNote: (note: Note | undefined) =>
         set((state) => {
           state.note = note;
+        }),
+
+      setNoteTimestamp: (timestamp) =>
+        set((state) => {
+          state.noteTimestamp = timestamp;
         }),
 
       setNoteId: (id) =>

--- a/apps/client/src/features/video/components/ui/video-note.tsx
+++ b/apps/client/src/features/video/components/ui/video-note.tsx
@@ -66,7 +66,12 @@ export function VideoNote({
         </div>
         <div className="flex items-center space-x-2 text-sm text-muted-foreground mt-2">
           <Clock className="h-4 w-4" />
-          <span>{note.timestamp}</span>
+          <span>
+            Start Timestamp: {Math.floor(note.timestamp.start * 100) / 100}
+          </span>
+          <span>
+            End Timestamp: {Math.floor(note.timestamp.end * 100) / 100}
+          </span>
         </div>
       </CardHeader>
     </Card>

--- a/apps/client/src/features/video/components/ui/video-player.tsx
+++ b/apps/client/src/features/video/components/ui/video-player.tsx
@@ -1,41 +1,41 @@
 "use client";
 
-import { useRef } from "react";
+import { useState } from "react";
 import YouTube, { type YouTubeProps } from "react-youtube";
 
 import { useNoteStore } from "@/features/note/store";
-import { useVideoStore } from "../../store";
 
 type VideoPlayerProps = {
   videoId?: string;
 };
 
 export function VideoPlayer({ videoId }: VideoPlayerProps) {
-  const playerRef = useRef<any | null>(null);
+  const [startTime, setStartTime] = useState<number>(0);
+
   const {
-    videoActions: { setVideoCurrentTime },
-  } = useVideoStore();
-  const { note } = useNoteStore();
+    note,
+    noteActions: { setNoteTimestamp },
+  } = useNoteStore();
 
-  const onPlayerReady: YouTubeProps["onReady"] = (event) => {
-    playerRef.current = event.target;
-
-    if (playerRef.current && note) {
-      playerRef.current.seekTo(note.timestamp);
+  const onPlayerReady: YouTubeProps["onReady"] = ({ target }) => {
+    if (note) {
+      target.seekTo(note.timestamp.start);
     }
   };
 
-  const onStateChange: YouTubeProps["onStateChange"] = (event) => {
-    // Check if the player is playing (state 1)
-    if (event.data === 1) {
-      const time = playerRef.current?.getCurrentTime() || 0;
-      setVideoCurrentTime(time);
-    }
+  const onPlay: YouTubeProps["onPlay"] = ({ target }) => {
+    const time = target.getCurrentTime();
+
+    setStartTime(time);
   };
 
-  const onPause: YouTubeProps["onPause"] = () => {
-    const time = playerRef.current?.getCurrentTime() || 0;
-    setVideoCurrentTime(time);
+  const onPause: YouTubeProps["onPause"] = ({ target }) => {
+    const time = target.getCurrentTime();
+
+    setNoteTimestamp({
+      start: startTime,
+      end: time,
+    });
   };
 
   const opts = {
@@ -54,8 +54,8 @@ export function VideoPlayer({ videoId }: VideoPlayerProps) {
         style={{ height: "100%" }}
         opts={opts}
         onReady={onPlayerReady}
-        onStateChange={onStateChange}
         onPause={onPause}
+        onPlay={onPlay}
       />
     </div>
   );

--- a/apps/client/src/features/video/store/video.store.ts
+++ b/apps/client/src/features/video/store/video.store.ts
@@ -4,14 +4,12 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 
 interface VideoState {
-  videoCurrentTime: number;
   isLoading: boolean;
   error: Error | null;
 }
 
 interface VideoStore extends VideoState {
   videoActions: {
-    setVideoCurrentTime: (time: number) => void;
     setLoading: (isLoading: boolean) => void;
     setError: (error: Error | null) => void;
   };
@@ -19,16 +17,10 @@ interface VideoStore extends VideoState {
 
 export const useVideoStore = create<VideoStore>()(
   immer((set) => ({
-    videoCurrentTime: 0,
     isLoading: false,
     error: null,
 
     videoActions: {
-      setVideoCurrentTime: (time) =>
-        set((state) => {
-          state.videoCurrentTime = time;
-        }),
-
       setLoading: (isLoading) =>
         set((state) => {
           state.isLoading = isLoading;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -98,18 +98,23 @@ model EmailVerificationToken {
   user User @relation(fields: [userId], references: [id])
 }
 
+type Timestamp {
+  start Float
+  end   Float
+}
+
 model Note {
-  id         String   @id @default(auto()) @map("_id") @db.ObjectId
+  id         String    @id @default(auto()) @map("_id") @db.ObjectId
   title      String
   content    String
-  timestamp  Float
+  timestamp  Timestamp
   videoTitle String
   thumbnail  String
   youtubeId  String
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-  userId     String   @db.ObjectId
-  videoId    String   @db.ObjectId
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+  userId     String    @db.ObjectId
+  videoId    String    @db.ObjectId
 
   video Video @relation(fields: [videoId], references: [id])
   user  User  @relation(fields: [userId], references: [id])

--- a/packages/dtos/src/note/create-note.dto.ts
+++ b/packages/dtos/src/note/create-note.dto.ts
@@ -4,5 +4,10 @@ export interface ICreateNoteDto {
   videoTitle: string;
   youtubeId: string;
   thumbnail: string;
-  timestamp: number;
+  timestamp: Timestamp;
+}
+
+export interface Timestamp {
+  start: number;
+  end: number;
 }

--- a/packages/schemas/src/note/create-note.schema.ts
+++ b/packages/schemas/src/note/create-note.schema.ts
@@ -30,6 +30,13 @@ export const createNoteSchema = z
     youtubeId: z
       .string()
       .min(3, { message: "Youtube id must be at least 3 characters long." }),
-    timestamp: z.number(),
+    timestamp: z.object({
+      start: z
+        .number()
+        .min(0, { message: "Start time must be a positive number." }),
+      end: z
+        .number()
+        .min(0, { message: "End time must be a positive number." }),
+    }),
   })
   .strict();

--- a/packages/schemas/src/note/update-note.schema.ts
+++ b/packages/schemas/src/note/update-note.schema.ts
@@ -21,6 +21,15 @@ export const updateNoteSchema = z
       .string()
       .min(10, { message: "Content must be at least 10 characters long." })
       .optional(),
-    timestamp: z.number().optional(),
+    timestamp: z
+      .object({
+        start: z
+          .number()
+          .min(0, { message: "Start time must be a positive number." }),
+        end: z
+          .number()
+          .min(0, { message: "End time must be a positive number." }),
+      })
+      .optional(),
   })
   .strict();


### PR DESCRIPTION
This pull request introduces a significant update to how timestamps are handled for notes, replacing the single `timestamp` value with a structured `Timestamp` object containing `start` and `end` fields. The changes span multiple areas, including the database schema, frontend components, and state management. Here's a summary of the key updates:

### Timestamps Refactor

* **Database Schema Update**: The `Note` model in the Prisma schema now uses a `Timestamp` object with `start` and `end` fields instead of a single `timestamp` float.
* **DTO and Validation Updates**: The `ICreateNoteDto` and `updateNoteSchema` now include the structured `Timestamp` object, with validation ensuring `start` and `end` are positive numbers. [[1]](diffhunk://#diff-d3012ac025f0c1e111b6a43ef350cbfca70bfe30f186946dbc633216c7654f1aL7-R12) [[2]](diffhunk://#diff-0430fe36bc85453040414251018be1123e7bc55aa6116d4f7975f034245ad432L33-R40) [[3]](diffhunk://#diff-eed80ccdb5723695acf68bb57051a2bfefbe115ea26ac7e48bdd1c6e8e78eb18L24-R33)

### Frontend State Management

* **New State in `useNoteStore`**: Added `noteTimestamp` to the `useNoteStore` state, along with a `setNoteTimestamp` action for managing start and end times. [[1]](diffhunk://#diff-faa4141b8731228d26cd8fc848e55574279becd2266008fb682d33b6e5d0166aL3-R10) [[2]](diffhunk://#diff-faa4141b8731228d26cd8fc848e55574279becd2266008fb682d33b6e5d0166aR22) [[3]](diffhunk://#diff-faa4141b8731228d26cd8fc848e55574279becd2266008fb682d33b6e5d0166aR34-R37) [[4]](diffhunk://#diff-faa4141b8731228d26cd8fc848e55574279becd2266008fb682d33b6e5d0166aR51-R55)
* **Removed `useVideoStore` Timestamp Logic**: The `videoCurrentTime` and related actions were removed from `useVideoStore`, as timestamp management is now handled in `useNoteStore`.

### Component Updates

* **Video Player**: Updated the `VideoPlayer` component to calculate and set `noteTimestamp` using `onPlay` and `onPause` events, replacing the previous `videoCurrentTime` logic. [[1]](diffhunk://#diff-7308f63004626dc697fa18cb3fe6613e0104318ce83380231fc6c580098965c8L3-R38) [[2]](diffhunk://#diff-7308f63004626dc697fa18cb3fe6613e0104318ce83380231fc6c580098965c8L57-R58)
* **Video Note Display**: Modified the `VideoNote` component to display both `start` and `end` timestamps instead of a single value.

### Page-Level Changes

* **Create and Update Note Pages**: Updated `CreateNotePage` and `UpdateNotePage` to use `noteTimestamp` from `useNoteStore` instead of `videoCurrentTime` from `useVideoStore`. [[1]](diffhunk://#diff-60d34703c81816c7ef4d86b1cffb12b407a31c9a398c9cbdbc53207d8d51c45bL7-R22) [[2]](diffhunk://#diff-60d34703c81816c7ef4d86b1cffb12b407a31c9a398c9cbdbc53207d8d51c45bL29-R31) [[3]](diffhunk://#diff-ed8dbccf18cd12d4082bc92ffbc70986a54aa4efe10bd1ede93499fec65d31eeL6-R14) [[4]](diffhunk://#diff-ed8dbccf18cd12d4082bc92ffbc70986a54aa4efe10bd1ede93499fec65d31eeL25-R25) 

These changes improve the flexibility and accuracy of timestamp management for notes, aligning the backend, frontend, and shared DTOs.